### PR TITLE
properly set PKCE values if client_secret is not present in configura…

### DIFF
--- a/cli/utils/generator.py
+++ b/cli/utils/generator.py
@@ -68,7 +68,7 @@ def generate_rendered_config_file(
 	    	"client_id": f"{client_id}",
 	    	"redirect_uri": f"https://{cloudfront_host}/_callback",
 	    	"grant_type": "authorization_code",
-	    	"client_secret": f"{client_secret}"
+	    	"client_secret": f"{client_secret}" if client_secret else None
 	    },
 	    "DISTRIBUTION": "amazon-oai",
 	    "AUTHN": f"{idp_name}",

--- a/src/js/auth.js
+++ b/src/js/auth.js
@@ -256,7 +256,7 @@ async function setConfig() {
 	}
 
 	// set PKCE values if client_secret is not present in configurations
-	if (config.TOKEN_REQUEST.client_secret == undefined){
+	if (!config.TOKEN_REQUEST.client_secret) {
 		config.AUTH_REQUEST.code_challenge_method = "S256";
 		config.AUTH_REQUEST.code_challenge = pkceCodeChallenge;
 		config.AUTH_REQUEST.state = "state";


### PR DESCRIPTION
Description of changes:

The following command (without client_secret params) works fine. However it generates "client_secret": "None" instead of "client_secret": null

```sh
python cli.py \
	--client_id client-id \ 
	--cloudfront_host cloudfront-host \
	--idp_domain_name idp-domain-name \
	--idp_name idp
```

The "None" value impacts on `auth.js` to set PKCE values (line 259)

```js
	// set PKCE values if client_secret is not present in configurations
	if (!config.TOKEN_REQUEST.client_secret) {
		config.AUTH_REQUEST.code_challenge_method = "S256";
		config.AUTH_REQUEST.code_challenge = pkceCodeChallenge;
		config.AUTH_REQUEST.state = "state";
		config.TOKEN_REQUEST.code_verifier = pkceCodeVerifier;
	}
```

My change fixes PKCE auth flow.